### PR TITLE
Revive D51728257 with fix (#1224)

### DIFF
--- a/lib/Platform/Unicode/PlatformUnicodeCF.cpp
+++ b/lib/Platform/Unicode/PlatformUnicodeCF.cpp
@@ -51,9 +51,10 @@ double localOffsetFromGMT() {
   }
 
   // Deconstruct the time into localTime.
-  std::tm *local = std::localtime(&currentWithDST);
+  std::tm tm;
+  std::tm *local = ::localtime_r(&currentWithDST, &tm);
   if (!local) {
-    llvm_unreachable("localtime failed in localOffsetFromGMT()");
+    return 0;
   }
 
   return local->tm_gmtoff * MS_PER_SECOND;

--- a/test/hermes/date-local-to-utc.js
+++ b/test/hermes/date-local-to-utc.js
@@ -6,6 +6,7 @@
  */
 
 // RUN: TZ="America/Santiago" %hermes -O %s | %FileCheck --match-full-lines %s
+// XFAIL: windows
 "use strict";
 
 // These tests ensure that local to UTC time conversion yields consistent result

--- a/unittests/VMRuntime/DateUtilTest.cpp
+++ b/unittests/VMRuntime/DateUtilTest.cpp
@@ -121,6 +121,16 @@ TEST(DateUtilTest, WeekDayTest) {
   EXPECT_EQ(3, weekDay(23415386789000)); // Wed, Jan 3, 2712
 }
 
+namespace {
+/// `localtime_r()` called in localTZA() caches the timezone. To correctly
+/// handle different timezones in a single test, let's call `tzset()` explicitly
+/// to update the cached timezone.
+void setTimeZone(const char *tzname) {
+  hermes::oscompat::set_env("TZ", tzname);
+  ::tzset();
+}
+} // namespace
+
 TEST(DateUtilTest, LocalTZATest) {
   // On Windows, TZ env can only be set to a very limited format,
   // as documented in Microsoft Docs for _tzset. Specifically,
@@ -135,9 +145,9 @@ TEST(DateUtilTest, LocalTZATest) {
 
   // US Pacific: DST is from Mar to Nov
 #ifdef _WINDOWS
-  hermes::oscompat::set_env("TZ", "PST8PDT");
+  setTimeZone("PST8PDT");
 #else
-  hermes::oscompat::set_env("TZ", "America/Los_Angeles");
+  setTimeZone("America/Los_Angeles");
 #endif
   EXPECT_EQ(-2.88e+7, localTZA());
 
@@ -145,7 +155,7 @@ TEST(DateUtilTest, LocalTZATest) {
 #ifdef _WINDOWS
   // This test is skipped due to Windows deficiency in TZ env variable.
 #else
-  hermes::oscompat::set_env("TZ", "Pacific/Auckland");
+  setTimeZone("Pacific/Auckland");
   EXPECT_EQ(4.32e+7, localTZA());
 #endif
 
@@ -154,17 +164,17 @@ TEST(DateUtilTest, LocalTZATest) {
 
   // Negative fixed zone
 #ifdef _WINDOWS
-  hermes::oscompat::set_env("TZ", "PST8");
+  setTimeZone("PST8");
 #else
-  hermes::oscompat::set_env("TZ", "Etc/GMT+8");
+  setTimeZone("Etc/GMT+8");
 #endif
   EXPECT_EQ(-2.88e+7, localTZA());
 
   // Positive fixed zone
 #ifdef _WINDOWS
-  hermes::oscompat::set_env("TZ", "JST-9");
+  setTimeZone("JST-9");
 #else
-  hermes::oscompat::set_env("TZ", "Asia/Tokyo");
+  setTimeZone("Asia/Tokyo");
 #endif
   EXPECT_EQ(3.24e+7, localTZA());
 
@@ -202,13 +212,13 @@ TEST(DateUtilTest, EquivalentTimeTest) {
 }
 
 TEST(DateUtilTest, DaylightSavingTATest) {
-  hermes::oscompat::set_env("TZ", "America/Los_Angeles");
+  setTimeZone("America/Los_Angeles");
   EXPECT_EQ(MS_PER_HOUR, daylightSavingTA(1489530532000)); // Mar 14, 2017
   EXPECT_EQ(MS_PER_HOUR, daylightSavingTA(1019514530000)); // Apr 22, 2002
   EXPECT_EQ(0, daylightSavingTA(1487111330000)); // Feb 14, 2017
   EXPECT_EQ(0, daylightSavingTA(1017700130000)); // Apr 1, 2002
 
-  hermes::oscompat::set_env("TZ", "America/Chicago");
+  setTimeZone("America/Chicago");
   EXPECT_EQ(MS_PER_HOUR, daylightSavingTA(1489530532000)); // Mar 14, 2017
   EXPECT_EQ(MS_PER_HOUR, daylightSavingTA(1019514530000)); // Apr 22, 2002
   EXPECT_EQ(0, daylightSavingTA(1487111330000)); // Feb 14, 2017
@@ -234,17 +244,17 @@ TEST(DateUtilTest, LocalTimeTest) {
   // 2018-07-02T01:00:00+0900[Asia/Tokyo] (DST not observed)
 
 #ifdef _WINDOWS
-  hermes::oscompat::set_env("TZ", "PST8PDT");
+  setTimeZone("PST8PDT");
 #else
-  hermes::oscompat::set_env("TZ", "America/Los_Angeles");
+  setTimeZone("America/Los_Angeles");
 #endif
   EXPECT_EQ(1530435600000, localTime(1530460800000));
   EXPECT_EQ(1530460800000, utcTime(1530435600000));
 
 #ifdef _WINDOWS
-  hermes::oscompat::set_env("TZ", "EST5EDT");
+  setTimeZone("EST5EDT");
 #else
-  hermes::oscompat::set_env("TZ", "America/New_York");
+  setTimeZone("America/New_York");
 #endif
   EXPECT_EQ(1530446400000, localTime(1530460800000));
   EXPECT_EQ(1530460800000, utcTime(1530446400000));
@@ -252,15 +262,15 @@ TEST(DateUtilTest, LocalTimeTest) {
 #ifdef _WINDOWS
   // This test is skipped due to Windows deficiency in TZ env variable.
 #else
-  hermes::oscompat::set_env("TZ", "Pacific/Auckland");
+  setTimeZone("Pacific/Auckland");
   EXPECT_EQ(1530504000000, localTime(1530460800000));
   EXPECT_EQ(1530460800000, utcTime(1530504000000));
 #endif
 
 #ifdef _WINDOWS
-  hermes::oscompat::set_env("TZ", "JST-9");
+  setTimeZone("JST-9");
 #else
-  hermes::oscompat::set_env("TZ", "Asia/Tokyo");
+  setTimeZone("Asia/Tokyo");
 #endif
   EXPECT_EQ(1530493200000, localTime(1530460800000));
   EXPECT_EQ(1530460800000, utcTime(1530493200000));


### PR DESCRIPTION
Summary:

Revive the localtime() thread safety change which is reverted due to crashes on Windows (D52210979). Fix is applied.

Differential Revision: D52213926

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
